### PR TITLE
chore(deps): updated pug-lint to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Gulp plugin to lint Pug (nee Jade) files",
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "pug-lint": "^2.1.6",
+    "pug-lint": "^2.2.0",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey @ilyakam, I just added the new version of pug-lint to the project so one will be able to use 'extend' in the config.

References:
https://github.com/pugjs/pug-lint/pull/69#issuecomment-222739944
https://github.com/pugjs/pug-lint/issues/79
