### PR TITLE
Custom and External Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ gulp.task('lint:template', function () {
 })
 ```
 
+Specify external modules as reporters using either the module's
+constructor or the module's name:
+
+```js
+// gulpfile.js
+var gulp = require('gulp')
+var pugLinter = require('gulp-pug-linter')
+var myPugLintReporter = require('my-pug-lint-reporter')
+
+gulp.task('lint:template', function () {
+  return gulp
+    .src('./**/*.pug')
+    .pipe(pugLinter())
+    .pipe(pugLinter.reporter(myPugLintReporter))
+})
+```
+
+  _- OR -_
+
+```js
+// gulpfile.js
+var gulp = require('gulp')
+var pugLinter = require('gulp-pug-linter')
+
+gulp.task('lint:template', function () {
+  return gulp
+    .src('./**/*.pug')
+    .pipe(pugLinter())
+    .pipe(pugLinter.reporter('my-pug-lint-reporter'))
+})
+```
+
 Specify your own custom reporter:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -53,3 +53,22 @@ gulp.task('lint:template', function () {
     .pipe(pugLinter.reporter('fail'))
 })
 ```
+
+Specify your own custom reporter:
+
+```js
+// gulpfile.js
+var gulp = require('gulp')
+var pugLinter = require('gulp-pug-linter')
+
+var myReporter = function (errors) {
+  if (errors.length) { console.error("It broke!"); }
+};
+
+gulp.task('lint:template', function () {
+  return gulp
+    .src('./**/*.pug')
+    .pipe(pugLinter())
+    .pipe(pugLinter.reporter(myReporter))
+})
+```

--- a/index.js
+++ b/index.js
@@ -17,11 +17,7 @@ function gulpPugLinter () {
    * @returns {Array} List of error messages
    */
   function checkFile (file) {
-    var errors = linter.checkFile(file.path)
-
-    return errors.map(function (error) {
-      return error.message
-    })
+    return linter.checkFile(file.path)
   }
 
   linter.configure(config)

--- a/reporter.js
+++ b/reporter.js
@@ -16,7 +16,9 @@ module.exports = function (hasToFail) {
     var allErrors
 
     if (errors.length) {
-      allErrors = errors.join('\n\n')
+      allErrors = errors.map(function (error) {
+        return error.message
+      }).join('\n\n')
 
       hasToFail
         ? this.emit('error', new gutil.PluginError(PLUGIN_NAME, allErrors))

--- a/reporter.js
+++ b/reporter.js
@@ -3,8 +3,39 @@ var throughObj = require('through2').obj
 
 const PLUGIN_NAME = 'gulp-pug-linter'
 
-module.exports = function (hasToFail) {
+var defaultReporter = function (errors) {
+  if (errors.length) {
+    var allErrors = errors.map(function (error) {
+      return error.message
+    }).join('\n\n')
+
+    gutil.log(allErrors)
+  }
+}
+
+var failReporter = function (errors) {
+  if (errors.length) {
+    var allErrors = errors.map(function (error) {
+      return error.message
+    }).join('\n\n')
+
+    this.emit('error', new gutil.PluginError(PLUGIN_NAME, allErrors))
+  }
+}
+
+var loadReporter = function (type) {
+  if (type == null) {
+    return defaultReporter
+  }
+  if (type === 'fail') {
+    return failReporter
+  }
+  throw new gutil.PluginError(PLUGIN_NAME, type + ' is not a valid reporter')
+}
+
+module.exports = function (type) {
   var errors = []
+  var reporter = loadReporter(type)
 
   return throughObj(function (file, encoding, callback) {
     if (file.pugLinter && file.pugLinter.errors.length) {
@@ -13,17 +44,7 @@ module.exports = function (hasToFail) {
 
     return callback(null, file)
   }, function (callback) {
-    var allErrors
-
-    if (errors.length) {
-      allErrors = errors.map(function (error) {
-        return error.message
-      }).join('\n\n')
-
-      hasToFail
-        ? this.emit('error', new gutil.PluginError(PLUGIN_NAME, allErrors))
-        : gutil.log(allErrors)
-    }
+    reporter.call(this, errors)
 
     return callback()
   })

--- a/reporter.js
+++ b/reporter.js
@@ -35,6 +35,11 @@ var loadReporter = function (type) {
   if (typeof type === 'function') {
     reporter = type
   }
+  if (typeof type === 'string') {
+    try {
+      reporter = require(type)
+    } catch (error) {}
+  }
 
   if (typeof reporter !== 'function') {
     throw new gutil.PluginError(PLUGIN_NAME, type + ' is not a valid reporter')

--- a/reporter.js
+++ b/reporter.js
@@ -30,7 +30,16 @@ var loadReporter = function (type) {
   if (type === 'fail') {
     return failReporter
   }
-  throw new gutil.PluginError(PLUGIN_NAME, type + ' is not a valid reporter')
+
+  var reporter
+  if (typeof type === 'function') {
+    reporter = type
+  }
+
+  if (typeof reporter !== 'function') {
+    throw new gutil.PluginError(PLUGIN_NAME, type + ' is not a valid reporter')
+  }
+  return reporter
 }
 
 module.exports = function (type) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -165,7 +165,7 @@ describe('gulp-pug-linter', function () {
     it('should stream a file that contains errors', function () {
       stream.on('data', function (processedFile) {
         expect(processedFile.pugLinter.errors)
-          .to.contain('some error')
+          .to.contain({message: 'some error'})
       })
     })
   })

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -49,6 +49,33 @@ describe('#reporter()', function () {
       mockery.deregisterAll()
     })
 
+    it('should report errors for named reporter', function () {
+      var funcReporter = function (errors) {}
+      var spiedReporter = sinon.spy(funcReporter)
+
+      mockery.enable({
+        useCleanCache: true,
+        warnOnUnregistered: false
+      })
+
+      mockery.registerMock('pug-mock-reporter', spiedReporter)
+
+      reporter = require('../reporter')
+
+      stream = reporter('pug-mock-reporter')
+
+      stream.write(streamFile)
+
+      stream.end()
+
+      expect(spiedReporter.calledWith([{message: 'some error'}]))
+        .to.be.ok
+
+      mockery.disable()
+
+      mockery.deregisterAll()
+    })
+
     it('should report errors for function reporter', function () {
       var funcReporter = function (errors) {}
 

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -19,7 +19,7 @@ describe('#reporter()', function () {
 
     streamFile.pugLinter = {errors: [{message: 'some error'}]}
 
-    it('should print the error', function () {
+    it('should print the error for default reporter', function () {
       gulpUtil = {log: function () {}}
 
       sinon.stub(gulpUtil)
@@ -49,6 +49,23 @@ describe('#reporter()', function () {
       mockery.deregisterAll()
     })
 
+    it('should report errors for function reporter', function () {
+      var funcReporter = function (errors) {}
+
+      var spy = sinon.spy(funcReporter)
+
+      reporter = require('../reporter')
+
+      stream = reporter(spy)
+
+      stream.write(streamFile)
+
+      stream.end()
+
+      expect(spy.calledWith([{message: 'some error'}]))
+        .to.be.ok
+    })
+
     it('should throw an error for missing reporter', function () {
       function shouldThrowError () {
         reporter = require('../reporter')
@@ -64,7 +81,7 @@ describe('#reporter()', function () {
         .to.throw('missingReporter is not a valid reporter')
     })
 
-    it('should throw an error when set to fail', function () {
+    it('should throw an error for fail reporter', function () {
       function shouldThrowError () {
         reporter = require('../reporter')
 
@@ -88,7 +105,7 @@ describe('#reporter()', function () {
       path: 'path.pug'
     })
 
-    it('should print no errors', function () {
+    it('should print no errors for default reporter', function () {
       gulpUtil = {log: function () {}}
 
       sinon.stub(gulpUtil)
@@ -116,6 +133,23 @@ describe('#reporter()', function () {
       mockery.disable()
 
       mockery.deregisterAll()
+    })
+
+    it('should report empty errors for function reporter', function () {
+      var funcReporter = function (errors) {}
+
+      var spy = sinon.spy(funcReporter)
+
+      reporter = require('../reporter')
+
+      stream = reporter(spy)
+
+      stream.write(streamFile)
+
+      stream.end()
+
+      expect(spy.calledWith([]))
+        .to.be.ok
     })
 
     it('should throw an error for missing reporter', function () {

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -17,7 +17,7 @@ describe('#reporter()', function () {
       path: 'path.pug'
     })
 
-    streamFile.pugLinter = {errors: ['some error']}
+    streamFile.pugLinter = {errors: [{message: 'some error'}]}
 
     it('should print the error', function () {
       gulpUtil = {log: function () {}}

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -49,6 +49,21 @@ describe('#reporter()', function () {
       mockery.deregisterAll()
     })
 
+    it('should throw an error for missing reporter', function () {
+      function shouldThrowError () {
+        reporter = require('../reporter')
+
+        stream = reporter('missingReporter')
+
+        stream.write(streamFile)
+
+        stream.end()
+      }
+
+      expect(shouldThrowError)
+        .to.throw('missingReporter is not a valid reporter')
+    })
+
     it('should throw an error when set to fail', function () {
       function shouldThrowError () {
         reporter = require('../reporter')
@@ -73,7 +88,52 @@ describe('#reporter()', function () {
       path: 'path.pug'
     })
 
-    it('should not throw an error', function () {
+    it('should print no errors', function () {
+      gulpUtil = {log: function () {}}
+
+      sinon.stub(gulpUtil)
+
+      mockery.enable({
+        useCleanCache: true,
+        warnOnUnregistered: false
+      })
+
+      mockery.registerMock('gulp-util', gulpUtil)
+
+      reporter = require('../reporter')
+
+      stream = reporter()
+
+      stream.write(streamFile)
+
+      stream.end()
+
+      expect(gulpUtil.log.called)
+        .to.not.be.ok
+
+      gulpUtil.log.restore()
+
+      mockery.disable()
+
+      mockery.deregisterAll()
+    })
+
+    it('should throw an error for missing reporter', function () {
+      function shouldThrowError () {
+        reporter = require('../reporter')
+
+        stream = reporter('missingReporter')
+
+        stream.write(streamFile)
+
+        stream.end()
+      }
+
+      expect(shouldThrowError)
+        .to.throw('missingReporter is not a valid reporter')
+    })
+
+    it('should not throw an error for fail reporter', function () {
       function shouldNotThrowError () {
         reporter = require('../reporter')
 


### PR DESCRIPTION
The current implementation of `gulp-pug-linter` only supports reporting using the plugin's built-in default and `fail` reporters. My intention with this PR is to extend the Reporter system to support external `pug-lint` reporters and custom reporter functions.

With this change, you can specify your own Reporter functions through three additional options:

### Custom Function
```js
var myFunction = function(errors) { if (errors.length) { console.log('It broke'); }};

gulp.src('**/*.pug')
    .pipe(pugLinter())
    .pipe(pugLinter.reporter(myFunction);
```

### External Module via Module Constructor
```js
var pugLintReporter = require('pug-lint-reporter');

gulp.src('**/*.pug')
    .pipe(pugLinter())
    .pipe(pugLinter.reporter(pugLintReporter);
```

### External Module via Module Name
```js
gulp.src('**/*.pug')
    .pipe(pugLinter())
    .pipe(pugLinter.reporter('pug-lint-reporter');
```

For external modules, you can also use `pug-lint`'s own reporters, located at `pug-lint/lib/reporters/console` and `pug-lint/lib/reporters/inline`.

Documentation has been updated to reflect these changes. Tests have also been written to cover the new functionality and maintain 100% test coverage.

## Breaking Change 
This PR aims to maintain all existing functionality, but there is one very minor breaking change. Though documentation directs developers to specify `pugLinter.reporter('fail')` to use the Fail Reporter, any truthy value will enable the Fail Reporter. With this change, specifying `'fail'` will still enable the Fail Reporter, but other truthy values will no longer load the Fail Reporter.

## Selfish Justification
I love this plugin, and the client uses JetBrain's TeamCity for continuous integration. My goal with this change is to allow PugLint reporting within TeamCity's message format, using the `pug-lint-teamcity` reporter, so that we can get error information directly within the build log, rather than getting only a generic error message and having to dig.