### PR TITLE
feat(reporter): allow custom and external reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Allow use of custom and external reporters
+
 ## [0.3.0] - 2016-06-13
 ### Added
 - Allow use of `extend` in `pug-lint`

--- a/README.md
+++ b/README.md
@@ -53,3 +53,54 @@ gulp.task('lint:template', function () {
     .pipe(pugLinter.reporter('fail'))
 })
 ```
+
+Specify external modules as reporters using either the module's
+constructor or the module's name:
+
+```js
+// gulpfile.js
+var gulp = require('gulp')
+var pugLinter = require('gulp-pug-linter')
+var myPugLintReporter = require('my-pug-lint-reporter')
+
+gulp.task('lint:template', function () {
+  return gulp
+    .src('./**/*.pug')
+    .pipe(pugLinter())
+    .pipe(pugLinter.reporter(myPugLintReporter))
+})
+```
+
+  _- OR -_
+
+```js
+// gulpfile.js
+var gulp = require('gulp')
+var pugLinter = require('gulp-pug-linter')
+
+gulp.task('lint:template', function () {
+  return gulp
+    .src('./**/*.pug')
+    .pipe(pugLinter())
+    .pipe(pugLinter.reporter('my-pug-lint-reporter'))
+})
+```
+
+Specify your own custom reporter:
+
+```js
+// gulpfile.js
+var gulp = require('gulp')
+var pugLinter = require('gulp-pug-linter')
+
+var myReporter = function (errors) {
+  if (errors.length) { console.error("It broke!"); }
+};
+
+gulp.task('lint:template', function () {
+  return gulp
+    .src('./**/*.pug')
+    .pipe(pugLinter())
+    .pipe(pugLinter.reporter(myReporter))
+})
+```

--- a/index.js
+++ b/index.js
@@ -17,11 +17,7 @@ function gulpPugLinter () {
    * @returns {Array} List of error messages
    */
   function checkFile (file) {
-    var errors = linter.checkFile(file.path)
-
-    return errors.map(function (error) {
-      return error.message
-    })
+    return linter.checkFile(file.path)
   }
 
   linter.configure(config)

--- a/reporter.js
+++ b/reporter.js
@@ -3,8 +3,79 @@ var throughObj = require('through2').obj
 
 const PLUGIN_NAME = 'gulp-pug-linter'
 
-module.exports = function (hasToFail) {
+/**
+ * @name defaultReporter
+ * @description Logs all errors via `gulp-util`
+ * @param {Array} errors Pug lint error objects with `message`
+ */
+var defaultReporter = function (errors) {
+  var allErrors
+
+  if (errors.length) {
+    allErrors = errors.map(function (error) {
+      return error.message
+    }).join('\n\n')
+
+    gutil.log(allErrors)
+  }
+}
+
+/**
+ * @name failReporter
+ * @description Emits a plugin error including all Pug lint errors at once
+ * @param {Array} errors Pug lint error objects with `message`
+ */
+var failReporter = function (errors) {
+  var allErrors
+
+  if (errors.length) {
+    allErrors = errors.map(function (error) {
+      return error.message
+    }).join('\n\n')
+
+    this.emit('error', new gutil.PluginError(PLUGIN_NAME, allErrors))
+  }
+}
+
+/**
+ * @name loadReporter
+ * @description Returns an error reporter
+ * @param {*} [type] 'fail' string to load a reporter that fails on error,
+ *                   any function or string to load a custom module reporter,
+ *                   or empty to load the default reporter.
+ * @returns {Function} Error reporter that accepts an array of errors
+ */
+var loadReporter = function (type) {
+  var reporter
+
+  if (type == null) {
+    return defaultReporter
+  }
+
+  if (type === 'fail') {
+    return failReporter
+  }
+
+  if (typeof type === 'function') {
+    reporter = type
+  }
+
+  if (typeof type === 'string') {
+    try {
+      reporter = require(type)
+    } catch (error) {}
+  }
+
+  if (typeof reporter !== 'function') {
+    throw new gutil.PluginError(PLUGIN_NAME, type + ' is not a valid reporter')
+  }
+
+  return reporter
+}
+
+module.exports = function (type) {
   var errors = []
+  var reporter = loadReporter(type)
 
   return throughObj(function (file, encoding, callback) {
     if (file.pugLinter && file.pugLinter.errors.length) {
@@ -13,15 +84,7 @@ module.exports = function (hasToFail) {
 
     return callback(null, file)
   }, function (callback) {
-    var allErrors
-
-    if (errors.length) {
-      allErrors = errors.join('\n\n')
-
-      hasToFail
-        ? this.emit('error', new gutil.PluginError(PLUGIN_NAME, allErrors))
-        : gutil.log(allErrors)
-    }
+    reporter.call(this, errors)
 
     return callback()
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -165,7 +165,7 @@ describe('gulp-pug-linter', function () {
     it('should stream a file that contains errors', function () {
       stream.on('data', function (processedFile) {
         expect(processedFile.pugLinter.errors)
-          .to.contain('some error')
+          .to.contain({message: 'some error'})
       })
     })
   })


### PR DESCRIPTION
Format error message on the reporter and provide it with data.
Add support for custom reporters while maintaining 'fail' as a viable
option so that continuous integration environments break as expected.
In addition, allow users to load reporters from modules, or by passing
a reporter function into this plugin.

BREAKING CHANGE:
Though the documentation directs using 'fail' as a reporter name to use
the fail reporter, any non-null value would trigger the fail reporter;
with this modification, any value other than null or 'fail' with throw
an invalid reporter error.

Closes PR #19 