### PR TITLE
Error: yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "sinon": "^1.17.4",
     "standard": "^8.0.0"
   },
-  "engines": {
-    "node": "5.*"
-  },
   "homepage": "https://github.com/ilyakam/gulp-pug-linter#readme",
   "keywords": [
     "gulp",


### PR DESCRIPTION
```bash
$ yarn install
```
```bash
error gulp-pug-linter@0.4.0: The engine "node" is incompatible with this module.
 Expected version "5.*".
error Found incompatible module
info Visit http://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
***
```bash
$ yarn install --ignore-engines
```
```bash
error gulp-pug-linter@0.4.0: The engine "node" is incompatible with this module.
 Expected version "5.*".
error Found incompatible module
info Visit http://yarnpkg.com/en/docs/cli/install for documentation about this command.
```