### PR TITLE
Error: yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "standard": "^8.0.0"
   },
   "engines": {
-    "node": "5.*"
+    "node": "<5"
   },
   "homepage": "https://github.com/ilyakam/gulp-pug-linter#readme",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "standard": "^8.0.0"
   },
   "engines": {
-    "node": "<5"
+    "node": "<6"
   },
   "homepage": "https://github.com/ilyakam/gulp-pug-linter#readme",
   "keywords": [


### PR DESCRIPTION
Do not set it directly
***
OS: Windows 10
Node `v.6.8.0`

```bash
$ yarn install
```
```bash
error gulp-pug-linter@0.4.0: The engine "node" is incompatible with this module.
 Expected version "5.*".
error Found incompatible module
info Visit http://yarnpkg.com/en/docs/cli/install for documentation about this command.
```