### PR TITLE
docs(README): adhere to StandardJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Update README examples to adhere to StandardJS
+
 ## [0.5.0] - 2017-06-17
 ### Changed
 - Bump Chai, Sinon, and StandardJS packages

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ var gulp = require('gulp')
 var pugLinter = require('gulp-pug-linter')
 
 var myReporter = function (errors) {
-  if (errors.length) { console.error("It broke!"); }
-};
+  if (errors.length) { console.error('It broke!') }
+}
 
 gulp.task('lint:template', function () {
   return gulp


### PR DESCRIPTION
Update the examples in `README.md` to make sure that they adhere to
the coding styles set forth by StandardJS. Desired outcome was done
by testing each individual JavaScript code snippet from the `README`
on the following page: https://standardjs.com/demo.html

Closes #29