### PR TITLE
chore(*): replace deprecated `gulp-util` with `plugin-error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Require packages using `proxyquire` instead of `mockery` in the unit tests
+- Replace deprecated `gulp-util` with `fancy-log`, `plugin-error`, and `vinyl`
 
 ### Fixed
 - Update CONTRIBUTING list items to be in order

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var configFile = require('pug-lint/lib/config-file')
-var PluginError = require('gulp-util').PluginError
+var PluginError = require('plugin-error')
 var PugLint = require('pug-lint')
 var throughObj = require('through2').obj
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   },
   "description": "Gulp plugin to lint Pug (nee Jade) files",
   "dependencies": {
-    "gulp-util": "^3.0.7",
+    "fancy-log": "^1.3.2",
+    "plugin-error": "^1.0.1",
     "pug-lint": "^2.2.2",
     "through2": "^2.0.1"
   },
@@ -17,7 +18,8 @@
     "mocha": "^3.0.1",
     "proxyquire": "^2.0.1",
     "sinon": "^2.3.4",
-    "standard": "^10.0.2"
+    "standard": "^10.0.2",
+    "vinyl": "^2.2.0"
   },
   "engines": {
     "node": ">=4.x"

--- a/reporter.js
+++ b/reporter.js
@@ -1,4 +1,5 @@
-var gutil = require('gulp-util')
+var fancyLog = require('fancy-log')
+var PluginError = require('plugin-error')
 var throughObj = require('through2').obj
 
 const PLUGIN_NAME = 'gulp-pug-linter'
@@ -16,7 +17,7 @@ var defaultReporter = function (errors) {
       return error.message
     }).join('\n\n')
 
-    gutil.log(allErrors)
+    fancyLog(allErrors)
   }
 }
 
@@ -33,7 +34,7 @@ var failReporter = function (errors) {
       return error.message
     }).join('\n\n')
 
-    this.emit('error', new gutil.PluginError(PLUGIN_NAME, allErrors))
+    this.emit('error', new PluginError(PLUGIN_NAME, allErrors))
   }
 }
 
@@ -67,7 +68,7 @@ var loadReporter = function (type) {
   }
 
   if (typeof reporter !== 'function') {
-    throw new gutil.PluginError(PLUGIN_NAME, type + ' is not a valid reporter')
+    throw new PluginError(PLUGIN_NAME, type + ' is not a valid reporter')
   }
 
   return reporter

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 var expect = require('chai').expect
-var gutil = require('gulp-util')
 var proxyquire = require('proxyquire')
 var sinon = require('sinon')
+var Vinyl = require('vinyl')
 
 describe('gulp-pug-linter', function () {
   var stream
@@ -74,7 +74,7 @@ describe('gulp-pug-linter', function () {
 
       gulpPugLinter = proxyquire('../index', {'pug-lint': mockPugLint})
 
-      file = new gutil.File({
+      file = new Vinyl({
         base: 'base',
         contents: Buffer.from(''),
         cwd: __dirname,
@@ -118,7 +118,7 @@ describe('gulp-pug-linter', function () {
 
       gulpPugLinter = proxyquire('../index', {'pug-lint': mockPugLint})
 
-      file = new gutil.File({
+      file = new Vinyl({
         base: 'base',
         contents: Buffer.from(''),
         cwd: __dirname,

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 var expect = require('chai').expect
-var gutil = require('gulp-util')
 var proxyquire = require('proxyquire')
 var sinon = require('sinon')
+var Vinyl = require('vinyl')
 
 describe('#reporter()', function () {
   var reporter
-  var mockGulpUtil
+  var mockFancyLog
   var mockReporter
   var stream
 
@@ -15,7 +15,7 @@ describe('#reporter()', function () {
     var streamFile
 
     beforeEach(function () {
-      streamFile = new gutil.File({
+      streamFile = new Vinyl({
         base: 'base',
         contents: Buffer.from(''),
         cwd: __dirname,
@@ -26,9 +26,9 @@ describe('#reporter()', function () {
     })
 
     it('should print the error for default reporter', function () {
-      mockGulpUtil = {log: sinon.stub()}
+      mockFancyLog = sinon.stub()
 
-      reporter = proxyquire('../reporter', {'gulp-util': mockGulpUtil})
+      reporter = proxyquire('../reporter', {'fancy-log': mockFancyLog})
 
       stream = reporter()
 
@@ -36,7 +36,7 @@ describe('#reporter()', function () {
 
       stream.end()
 
-      expect(mockGulpUtil.log.calledWith('some error'))
+      expect(mockFancyLog.calledWith('some error'))
         .to.be.ok
     })
 
@@ -114,7 +114,7 @@ describe('#reporter()', function () {
     var streamFile
 
     beforeEach(function () {
-      streamFile = new gutil.File({
+      streamFile = new Vinyl({
         base: 'base',
         contents: Buffer.from(''),
         cwd: __dirname,
@@ -123,9 +123,9 @@ describe('#reporter()', function () {
     })
 
     it('should print no errors for default reporter', function () {
-      mockGulpUtil = {log: sinon.stub()}
+      mockFancyLog = sinon.stub()
 
-      reporter = proxyquire('../reporter', {'gulp-util': mockGulpUtil})
+      reporter = proxyquire('../reporter', {'fancy-log': mockFancyLog})
 
       stream = reporter()
 
@@ -133,7 +133,7 @@ describe('#reporter()', function () {
 
       stream.end()
 
-      expect(mockGulpUtil.log.called)
+      expect(mockFancyLog.called)
         .to.not.be.ok
     })
 


### PR DESCRIPTION
Change gulp-util dependencies due to deprecation of gulp-util package in December 2017. This commit will remove the deprecation message when adding gulp-pug linter to a project through npm.

Closes ilyakam/gulp-pug-linter#34