### PR TITLE
chore(.gitignore): ignore template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.jade
+*.pug
 .coveralls.yml
 .DS_Store
 .pug-lint.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Update CONTRIBUTING list items to be in order
+- Ignore all `*.pug` and `*.jade` files in this repository
 
 ## [0.5.1] - 2017-06-17
 ### Fixed


### PR DESCRIPTION
Ignore all template files that may be used for local testing.
Specifically, ignore `*.pug` and `*.jade` files in this repository.

Closes #39