### PR TITLE
docs(readme): add Greenkeeper badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Greenkeeper to automatically keep dependencies up to date
+
 ### Fixed
 - Update CONTRIBUTING list items to be in order
 - Ignore all `*.pug` and `*.jade` files in this repository

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Gulp plugin to lint Pug (nee Jade) files
 [![Coverage Status](https://coveralls.io/repos/github/ilyakam/gulp-pug-linter/badge.svg?branch=develop)](https://coveralls.io/github/ilyakam/gulp-pug-linter?branch=develop)
 [![Dependency Status](https://david-dm.org/ilyakam/gulp-pug-linter.svg)](https://david-dm.org/ilyakam/gulp-pug-linter)
 [![Code Style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/ilyakam/gulp-pug-linter.svg)](https://greenkeeper.io/)
 
 ## About
 


### PR DESCRIPTION
https://greenkeeper.io/

---

[According to the Greenkeeper Documentation](https://greenkeeper.io/docs.html#enabling_a_repo), this `greenkeeper/initial` branch needs to be merged into the project in order for it to be enabled.

> Enable Greenkeeper on that individual repository by merging the Initial Pull Request.
> 
> To set itself up on a repository, Greenkeeper will open an Initial Pull Request. This will attempt to update all dependencies at once, so you’re up to date. In addition, it will add the Greenkeeper badge to your project’s `readme.md`. Note that Greenkeeper will only be able to do this if your repository meets [all the prerequisites](https://greenkeeper.io/docs.html#prerequisites).