### PR TITLE
test(index, reporter): replace `mockery` with `proxyquire`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Greenkeeper to automatically keep dependencies up to date
 - Ability to automatically run tests on change with `npm run watch`
 
+### Changed
+- Require packages using `proxyquire` instead of `mockery` in the unit tests
+
 ### Fixed
 - Update CONTRIBUTING list items to be in order
 - Ignore all `*.pug` and `*.jade` files in this repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Greenkeeper to automatically keep dependencies up to date
+- Ability to automatically run tests on change with `npm run watch`
 
 ### Fixed
 - Update CONTRIBUTING list items to be in order

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ However, the project is being developed by the community. You're encouraged to c
 
 #### unit tests
 
-1. Run `npm run coverage`
+1. Run `npm run watch` and it will automatically rerun the tests on change
 
 ## Commit Guidelines
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp": "^3.9.1",
     "istanbul": "^0.4.2",
     "mocha": "^3.0.1",
-    "mockery": "^2.0.0",
+    "proxyquire": "^2.0.1",
     "sinon": "^2.3.4",
     "standard": "^10.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "url": "git+https://github.com/ilyakam/gulp-pug-linter.git"
   },
   "scripts": {
-    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec",
-    "coveralls": "npm run-script coverage && node ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info",
+    "coverage": "istanbul cover _mocha -- -R spec",
+    "coveralls": "npm run coverage && coveralls < coverage/lcov.info",
     "pretest": "standard",
-    "test": "npm run-script coveralls"
+    "test": "npm run coveralls",
+    "watch": "mocha --watch || exit 0"
   },
   "version": "0.5.1"
 }


### PR DESCRIPTION
chore(package): automatically run tests on change

Update the "scripts" portion of `package.json` so that it:

1. automatically runs test on `npm run watch`
2. references the packages' in their `./node_mudules/.bin/` locations
3. exits without throwing any errors (e.g., `ELIFECYCLE`)

This commit also updates the `CONTRIBUTING` guide to reflect the changes

Tested with the following Node.js versions:

- 4.9.1
- 5.12.0
- 8.11.3 (current LTS)

---

test(index, reporter): replace `mockery` with `proxyquire`

Switch from `mockery` to `proxyquire` so that it is possible to load
packages that export a function as opposed to an object. Simplify the
codebase by removing a lot of unnecessary boilerplate from the tests.

Closes #42