### PR TITLE
chore(*): release version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.2.1] - 2019-07-18
 ### Fixed
 - Bump the Node.js engine to match the ES2017 syntax in this project
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pug-linter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "pretest": "npm run lint",
     "test": "jest"
   },
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
## [1.2.1] - 2019-07-18
### Fixed
- Bump the Node.js engine to match the ES2017 syntax in this project

### Security
- Bump Lodash to version `4.17.15` to address vulnerability with `defaultsDeep`
