### PR TITLE
Create FUNDING.yml with Tidelift key

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+tidelift: npm/gulp-pug-linter


### PR DESCRIPTION
Hey @ilyakam! I noticed that you didn't have a FUNDING.yml file which is required to unlock the new Tidelift enterprise marketing language. This adds the file but you still need to enable "Sponsorships" in "Settings".