### PR TITLE
docs(README): replace Greenkeeper badge with Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gulp plugin to lint Jade or Pug files
 [![Dependencies Status](https://david-dm.org/ilyakam/gulp-pug-linter/status.svg)](https://david-dm.org/ilyakam/gulp-pug-linter)
 [![Dev Dependencies Status](https://david-dm.org/ilyakam/gulp-pug-linter/dev-status.svg)](https://david-dm.org/ilyakam/gulp-pug-linter?type=dev)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-green.svg)](https://conventionalcommits.org)
-[![Greenkeeper badge](https://badges.greenkeeper.io/ilyakam/gulp-pug-linter.svg)](https://greenkeeper.io/)
+[![Known Vulnerabilities](https://snyk.io/test/github/ilyakam/gulp-pug-linter/badge.svg)](https://snyk.io/test/github/ilyakam/gulp-pug-linter)
 
 ## About
 


### PR DESCRIPTION
[Greenkeeper](https://greenkeeper.io/) ceased its operations. It recommended to use [Snyk](https://snyk.io/) instead.
This commit updates the `README` badge to reflect the new changes.

---

### Screenshots:

#### Before:

![01 before](https://user-images.githubusercontent.com/183227/90963863-557dcf80-e470-11ea-97c6-2cfee6a7ba6b.png)

#### After:

![02 after](https://user-images.githubusercontent.com/183227/90963867-5b73b080-e470-11ea-96d4-7d1cc90ef76c.png)
