### PR TITLE
feat(report): only report if there are errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ const gulpPugLinter = (options = {}) => {
 
     const errors = checkFile(file);
 
-    if (Object.keys(options).includes('reporter')) {
+    if (errors.length && Object.keys(options).includes('reporter')) {
       getReporter(options.reporter)(errors);
     }
 


### PR DESCRIPTION
When calling similar gulp linters, such as `gulp-jshint`, no message is displayed when everything succeeds. Messages are only displayed when a problem occurs. I request updating this tool so that it does the same thing, only passing errors to the reporter if there are errors to report. The functionality is already in place for the default reporter; this would extend it to all reports.

This cleans up the gulp log quite a bit, getting rid of the "It worked!" pug-lint messages while still keeping the "It worked!" functionality in place with the reporters when using other pug-lint implementations.