### PR TITLE
feat(*): add option to bypass the reporter when there are no errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Option to bypass the reporter entirely when there are no errors
+
 ## [1.4.0] - 2020-08-18
 ### Changed
 - [BREAKING CHANGE] Require Node.js engine v10 and higher

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ $ npm install gulp-pug-linter --save-dev
 
 ## Options
 
-* `failAfterError` - whether to throw a plugin error after encountering one or more lint errors
-* `reporter` - reporter type, name, module, or function to show lint errors
+* `failAfterError` - whether to throw a plugin error after encountering one or more lint errors (default: `false`)
+* `reporter` - reporter type, name, module, or function to show lint errors (default: `'default'`)
+* `silenceOnSuccess` - whether to bypass the reporter when there are no lint errors (default: `false`)
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ const getReporter = (reporter) => {
  * @param {Boolean} failAfterError Whether to throw a plugin error after
  *                                 encountering one or more lint errors
  * @param {*} reporter Reporter type, name, or function to show lint errors
+ * @param {Boolean} silenceOnSuccess Whether to bypass the reporter when there
+ *                                   are no lint errors
  */
 const gulpPugLinter = (options = {}) => {
   const config = configFile.load();
@@ -69,11 +71,17 @@ const gulpPugLinter = (options = {}) => {
 
     const errors = checkFile(file);
 
+    const hasErrors = errors.length > 0;
+
     if (Object.keys(options).includes('reporter')) {
-      getReporter(options.reporter)(errors);
+      const reporter = getReporter(options.reporter);
+
+      if (hasErrors || !options.silenceOnSuccess) {
+        reporter(errors);
+      }
     }
 
-    if (options.failAfterError && errors.length) {
+    if (options.failAfterError && hasErrors) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Lint failed'));
     }
 

--- a/index.test.js
+++ b/index.test.js
@@ -133,6 +133,21 @@ describe('gulp-pug-linter', () => {
             .not.toHaveBeenCalled();
         });
       });
+
+      test('should not show any messages on silenceOnSuccess', () => {
+        const gulpPugLinter = require('./index');
+        const mockReporter = jest.fn();
+
+        stream = gulpPugLinter({
+          reporter: mockReporter,
+          silenceOnSuccess: true,
+        });
+
+        stream.on('data', () => {
+          expect(mockReporter)
+            .not.toHaveBeenCalled();
+        });
+      });
     });
 
     describe('when there are some errors', () => {


### PR DESCRIPTION
Add the ability to skip calling the reporter by setting the option
`silenceOnSuccess` to `true`. Thus when the codebase has no issues,
the developers won't be distracted by any messages that would have
otherwise been produced by this plugin.

Closes #80